### PR TITLE
Freeze transifex-client to 0.12.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ cache:
   - node_modules
 before_install:
 - curl -fsSL https://bootstrap.pypa.io/get-pip.py | python3.5 - --user
-- travis_retry pip3.5 install --user transifex-client
+- travis_retry pip3.5 install --user transifex-client==0.12.5
 - install -m0644 .transifexrc.tpl ~/.transifexrc
 - echo "password = $TX_PASSWD" >> ~/.transifexrc
 script:


### PR DESCRIPTION
Hi @gcoter 👋 

The latest version of the `transifex` CLI added a prompt for when the authentication fails. It breaks your Travis CI build here since you don't use transifex project for now. ~~But it seems that [the `--no-interactive` option](https://github.com/transifex/transifex-client/issues/129) must be used to skip it, so let's try it.~~ 

~~If it works, I will update `create-cozy-app` templates consequently :)~~